### PR TITLE
patch: tool call response handling

### DIFF
--- a/packages/builder/package.json
+++ b/packages/builder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ozone-builder",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "effect": "^3.14.14",
-    "ozone-model": "^0.0.1",
+    "ozone-model": "^0.0.2",
     "ozone-router": "^0.0.1",
     "zod": "^3.24.3",
     "zod-to-json-schema": "^3.24.5"

--- a/packages/model/package.json
+++ b/packages/model/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ozone-model",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/model/src/index.ts
+++ b/packages/model/src/index.ts
@@ -16,6 +16,7 @@ export interface ModelOutput {
     role?: "user" | "assistant" | "system"
     answer: string | undefined;
     toolResponses?: Array<{ name: string, args: Record<string, any>, id?: string }> | undefined
+    toolCallResults?: Array<{ id: string, tool: string, content: string }>
 }
 
 export class Model {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,8 +14,8 @@ importers:
         specifier: ^3.14.14
         version: 3.14.14
       ozone-model:
-        specifier: ^0.0.1
-        version: 0.0.1
+        specifier: ^0.0.2
+        version: 0.0.2
       ozone-router:
         specifier: ^0.0.1
         version: 0.0.1
@@ -819,6 +819,9 @@ packages:
 
   ozone-model@0.0.1:
     resolution: {integrity: sha512-oKCZFwK0bH+DZT32lGucvsJnr9JjjeYMSzQ0PkraaLdHjzI/hVq5TQEU4OeVM1cjvbJ8cdnQ5CqAi1YbjPLU/w==}
+
+  ozone-model@0.0.2:
+    resolution: {integrity: sha512-UPTlaHugdDSOp6277LTA1cITYaCA+y+lOGrkEjKXGo+taZ4AK5rX2+GLJ1qYfvX8sdpE/wwjZiA4DfU0hEs3kQ==}
 
   ozone-router@0.0.1:
     resolution: {integrity: sha512-0hYfwdoeSqxcN15UliK/eaTZXlzffnivMdC45zk9emURtZJPvcEJ8AP3z56m6kevb+PSgAj8lbyoNQt3bTsw1A==}
@@ -1667,6 +1670,10 @@ snapshots:
       zod-to-json-schema: 3.24.5(zod@3.24.3)
 
   ozone-model@0.0.1:
+    dependencies:
+      effect: 3.14.14
+
+  ozone-model@0.0.2:
     dependencies:
       effect: 3.14.14
 


### PR DESCRIPTION
This pull request introduces several key improvements to the agent execution and tool handling logic in the builder package, along with updates to the model package and dependency versions. The most significant changes include enhanced validation and error handling for tool responses, support for multiple tool calls per step, and new hooks for chat history management. These updates improve robustness, extensibility, and traceability of agent interactions.

**Tool Handling and Validation Improvements**
* Added validation for tool responses to ensure only expected tools are processed, with a new `INVALID_TOOLS_SELECTED` signal for error handling. Multiple tool responses are now supported per step, and results are appended to `toolCallResults` in `ModelOutput`. [[1]](diffhunk://#diff-0132391a0599242b071a1590a01194ae5a6838710484de27aa758d7bb081ef80L18-R19) [[2]](diffhunk://#diff-0132391a0599242b071a1590a01194ae5a6838710484de27aa758d7bb081ef80L558-R661) [[3]](diffhunk://#diff-5b95143605985f120e9f839ad573a9d4d328de4554c328d50fe98e6d1b601b6cR19)
* Improved argument validation for tool calls, with explicit error signaling when validation fails.

**Agent Execution and History Management**
* Added hooks for loading and updating chat history via `addInitLoader`, `addUpdater`, and `addChatHistory` methods, allowing for asynchronous history management and error handling. [[1]](diffhunk://#diff-0132391a0599242b071a1590a01194ae5a6838710484de27aa758d7bb081ef80L258-R260) [[2]](diffhunk://#diff-0132391a0599242b071a1590a01194ae5a6838710484de27aa758d7bb081ef80R319-R342)
* Introduced an `init` method to load previous conversation history before agent execution, improving state management across sessions.

**API and Type Updates**
* Updated the `Tool` type to require the `handle` method to return an object, standardizing tool outputs.
* Updated the `run` method to preserve the execution stack and trigger prompt handling.

**Dependency and Version Updates**
* Bumped `ozone-builder` and `ozone-model` package versions to `0.0.3` and `0.0.2` respectively, and updated dependencies in `package.json` and `pnpm-lock.yaml` to reflect these changes. [[1]](diffhunk://#diff-a549d2657aa3ea787f685c405385a2c352488058096cb3c4d68a4ab82bf3bf50L3-R3) [[2]](diffhunk://#diff-a549d2657aa3ea787f685c405385a2c352488058096cb3c4d68a4ab82bf3bf50L21-R21) [[3]](diffhunk://#diff-d9e8831455a001889106328a9978dcc1401a68716ee552aa8c5ad989127e192dL3-R3) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL17-R18) [[5]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR823-R825) [[6]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR1676-R1679)